### PR TITLE
Remove unsafe from code and scan all event devices

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -269,7 +269,8 @@ fn discover_mouse_devices() -> Vec<PathBuf> {
     let mut paths = Vec::new();
     for entry in dir.flatten() {
         let name = entry.file_name();
-        if name.as_encoded_bytes().ends_with(b"-event-mouse") {
+        let is_event = name.to_str().unwrap().contains("-event");
+        if is_event {
             match std::fs::canonicalize(entry.path()) {
                 Ok(p) => paths.push(p),
                 Err(e) => warn!("canonicalize {:?}: {e}", entry.path()),


### PR DESCRIPTION
The code I changed where unsafe is used panics when running normally (Arch Linux) so I replaced it for a safe version. It's less optimized though I think it's not that important than reliability

I also experimented with scanning and using all event devices, not only mouse ones and it works. It may break with controllers with gyroscope though I think gyro data is usually sent via hidraw, not event